### PR TITLE
Add validation to article model schema

### DIFF
--- a/src/app/article.js
+++ b/src/app/article.js
@@ -13,7 +13,12 @@ export default {
         article.tags = tags;
 
         // TODO: user_id and timezone must be included after authentication is implemented
-        article.save();
+        try {
+            await article.save();
+        } catch (error) {
+            //error.errors.properties.message
+            return new CreateArticleOutputDto({}, false, JSON.stringify(error.errors))
+        }
 
         return new CreateArticleOutputDto(article);
     },
@@ -42,7 +47,12 @@ export default {
         article.body = body;
         article.tags = tags;
 
-        article.save();
+        try {
+            await article.save();
+        } catch (error) {
+            //error.errors.properties.message
+            return new CreateArticleOutputDto({}, false, JSON.stringify(error.errors))
+        }
 
         return new UpdateArticleOutputDto(article, true, "Article updated successfully");
     },

--- a/src/app/models/article.model.js
+++ b/src/app/models/article.model.js
@@ -6,11 +6,13 @@ class Article extends BaseModel {
         title: {
             type: String,
             minLength: [3, "Title must have at least 3 characters"],
-            maxLength: 250
+            maxLength: 250,
+            required: [true, "Title is a required field"]
         },
         body: {
             type: String,
-            maxLength: 500000
+            maxLength: 500000,
+            required: [true, "Body is a required field"]
         },
         tags: {
             type: [String],
@@ -20,8 +22,8 @@ class Article extends BaseModel {
                         return false
                     }
                 }
-                return value.length > 0 && value.length <= 10
-            }, 'Needs at least 1 tag, max of 10 and must have at least 2 characters']
+                return value.length <= 10
+            }, 'You can only have a max of 10 tags and each of them must have at least 2 characters']
         },
         user_id: String,
         timezone: {

--- a/src/app/models/article.model.js
+++ b/src/app/models/article.model.js
@@ -3,11 +3,32 @@ import { Schema } from 'mongoose'
 
 class Article extends BaseModel {
     static SCHEMA = new Schema({
-        title: String,
-        body: String,
-        tags: [String],
+        title: {
+            type: String,
+            minLength: [3, "Title must have at least 3 characters"],
+            maxLength: 250
+        },
+        body: {
+            type: String,
+            maxLength: 500000
+        },
+        tags: {
+            type: [String],
+            validate: [(value) => {
+                for (let k in value) {
+                    if (value[k].length < 2) {
+                        return false
+                    }
+                }
+                return value.length > 0 && value.length <= 10
+            }, 'Needs at least 1 tag, max of 10 and must have at least 2 characters']
+        },
         user_id: String,
-        timezone: String
+        timezone: {
+            type: String,
+            min: 4,
+            max: 5
+        }
     })
 }
 

--- a/src/common/dto/article/create.dto.js
+++ b/src/common/dto/article/create.dto.js
@@ -3,7 +3,7 @@ import { BaseOutputDto } from "../dto.js";
 
 class CreateArticleInputDto {
     static SCHEMA = Joi.object({
-        title: Joi.string().min(3).max(500).required(),
+        title: Joi.string().min(3).max(250).required(),
         body: Joi.string().max(500000).required(),
         tags: Joi.array().items(Joi.string().min(2).max(30).pattern(new RegExp("^[A-z0-9 _-]*$"))),
         // Regex: alphanum + whitespace + underscore + dash

--- a/src/http/article.controller.js
+++ b/src/http/article.controller.js
@@ -13,6 +13,10 @@ class ArticleController extends BaseController {
             const dto = new CreateArticleInputDto(req.body);
             const result = await service.create(dto);
 
+            if (!result.success) {
+                throw new HttpException(400, result.info);
+            }
+
             return res.status(200).send(`Article [${result._id}] created successfully!`);
         } catch (error) {
             this.reportBadData(error, req.body);


### PR DESCRIPTION
Closes #28 

- Creates validation for the SCHEMA class, should not be needed as we are now but a "just in case" layer of security
- Updates the maximum allowed number of characters for the article title on the dto
<br />

Todo:
- Catch 400 errors
- Change the result.success on the update method in the service (should have a way to distinguish if the error comes from a not found or invalid data)
<br />

As it is, the error we're catching for the SCHEMA validation is the entire error.errors object, not very user friendly but really easy to change if it's ever needed